### PR TITLE
This is a work in progress for the config reloading feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,12 +309,15 @@ This will place goguerrilla in the background and continue running
 You may also put another process to watch your goguerrilla process and re-start it
 if something goes wrong.
 
-Testing STARTTLS
-
-Use openssl:
+Testing STARTTLS, Use openssl:
+(On port 2526, tls_always_on:false, start_tls_on:true)
 
     $ openssl s_client -starttls smtp -crlf -connect 127.0.0.1:2526
 
+Testing SSL only server:
+(On port 2526, tls_always_on:false, start_tls_on:false)
+
+    $ openssl s_client -crlf -connect 127.0.0.1:2526 -state
 
 Reload Config without restarting
 ================================
@@ -332,7 +335,7 @@ The new configuration will go in effect for all new connections.
 Benchmarking:
 ==========================================================
 
-http://www.jrh.org/smtp/index.html
+https://web.archive.org/web/20110725141905/http://www.jrh.org/smtp/index.html
 Test 500 clients:
 
     $ time smtp-source -c -l 5000 -t test@spam4.me -s 500 -m 5000 5.9.7.183

--- a/README.md
+++ b/README.md
@@ -8,38 +8,38 @@ An minimalist SMTP server written in Go, made for receiving large volumes of mai
 
 ### What is Go Guerrilla SMTPd?
 
-It's a small SMTP server written in Go, for the purpose of receiving large volume of email.
-Written for GuerrillaMail.com which processes tens of thousands of emails
-every hour.
+It's a small SMTP server written in Go, for the purpose of receiving 
+large volume of email. Written for GuerrillaMail.com which processes 
+hundreds of thousands of emails every hour.
 
-The purpose of this daemon is to grab the email, save it to the database
-and disconnect as quickly as possible.
+The purpose of this daemon is to grab the emails, save them to the 
+backend and disconnect as quickly as possible. The server includes 
+features for TLS/STARTTLS, hot-reloading of the configuration, 
+with the ability to run multiple servers listening on different ports 
+and interfaces.
 
-A typical user of this software would probably want to customize the save_mail.go source for
-their own systems.
+A typical user of this software would probably want to look into 
+`backends/guerrilla_db_redis.go` source file to use as an example to 
+customize for their own systems.
 
-This server does not attempt to filter HTML, check for spam or do any sender 
-verification. These steps should be performed by other programs.
-The server does NOT send any email including bounces. This should
-be performed by a separate program.
+This server does not attempt to filter HTML, check for spam or do any 
+sender verification. These steps should be performed by other programs,
+ (or perhaps your own custom backend?).
+The server does not send any email including bounces.
 
 The software is using MIT License (MIT) - contributors welcome.
 
 ### Roadmap / Contributing & Bounties
 
 
-Pull requests / issue reporting & discussion / code reviews always welcome.
-To encourage more pull requests, we are now offering bounties funded 
-from our bitcoin donation address:
+Pull requests / issue reporting & discussion / code reviews always 
+welcome. To encourage more pull requests, we are now offering bounties 
+funded from our bitcoin donation address:
 
 `1grr11aWtbsyMUeB4EGfHvTuu7eFzkJ4A`
 
 So far we have the following bounties:
 
-- Client Pooling: When a client is finished, it should be placed into a 
-pool instead of being destroyed. Looking for a idiomatic 
-Go solution with channels. (0.5 BTC for a successful merge)
-See discussion here: https://github.com/flashmob/go-guerrilla/issues/11
 
 - Modularize: Ability for the server to be used as a package. If it used
 as a package, an API would be exposed, and a new program would be able 
@@ -91,50 +91,16 @@ event driven I/O (2012). A year later, the latest script also became inadequate
 
 Getting started
 ===========================
+(Assuming that you have GNU make and latest Go on your system)
 
 To build, just run
 
-$ make guerrillad
+`$ make guerrillad`
 
 Then rename goguerrilla.conf.sample to goguerrilla.conf
 
-By default, the saveMail() function saves the meta-data of an email
-into MySQL while the body is saved in Redis.
-
-If you want to use the default saveMail() function, setup the following table
-in MySQL:
-
-	CREATE TABLE IF NOT EXISTS `new_mail` (
-	  `mail_id` int(11) NOT NULL auto_increment,
-	  `date` datetime NOT NULL,
-	  `from` varchar(128) character set latin1 NOT NULL,
-	  `to` varchar(128) character set latin1 NOT NULL,
-	  `subject` varchar(255) NOT NULL,
-	  `body` text NOT NULL,
-	  `charset` varchar(32) character set latin1 NOT NULL,
-	  `mail` longblob NOT NULL,
-	  `spam_score` float NOT NULL,
-	  `hash` char(32) character set latin1 NOT NULL,
-	  `content_type` varchar(64) character set latin1 NOT NULL,
-	  `recipient` varchar(128) character set latin1 NOT NULL,
-	  `has_attach` int(11) NOT NULL,
-	  `ip_addr` varchar(15) NOT NULL,
-	  `delivered` bit(1) NOT NULL default b'0',
-	  `attach_info` text NOT NULL,
-	  `dkim_valid` tinyint(4) default NULL,
-	  PRIMARY KEY  (`mail_id`),
-	  KEY `to` (`to`),
-	  KEY `hash` (`hash`),
-	  KEY `date` (`date`)
-	) ENGINE=InnoDB  DEFAULT CHARSET=utf8
-
-The above table does not store the body of the email which makes it quick
-to query and join, while the body of the email is fetched from Redis 
-if needed.
-
-You can implement your own saveMail function to use whatever storage /
-backend fits for you.
-
+See `backends/guerrilla_db_redis.go` source to use an example for creating your own email saving backend, 
+or the dummy one if you'd like to start from scratch.
 
 Configuration
 ============================================
@@ -144,56 +110,75 @@ Copy goguerrilla.conf.sample to goguerrilla.conf
 
     {
         "allowed_hosts": "guerrillamail.com,guerrillamailblock.com,sharklasers.com,guerrillamail.net,guerrillamail.org" // What hosts to accept 
-        "primary_mail_host":"sharklasers.com", // main domain
-        "verbose":false, // report all events to log
-        "mysql_db":"gmail_mail", // name of mysql database
-        "mysql_host":"127.0.0.1:3306", // mysql host and port (tcp)
-        "mysql_pass":"ok", // mysql password
-        "mysql_user":"gmail_mail", // mysql username
-        "mail_table":"new_mail", // mysql save table. Email meta-data is saved there
-        "redis_interface" : "127.0.0.1:6379", // redis host and port, email data payload is saved there
-        "redis_expire_seconds" : 3600, // how long to keep in redis
-        "save_workers_size" : 3, // number workers saving email from all servers
         "pid_file" : "/var/run/go-guerrilla.pid", // pid = process id, so that other programs can send signals to our server
-            "servers" : [ // the following is an array of objects, each object represents a new server that will be spawned
-                {
-                    "is_enabled" : true, // boolean
-                    "host_name":"mail.test.com", // the hostname of the server as set by MX record
-                    "max_size": 1000000, // maximum size of an email in bytes
-                    "private_key_file":"/path/to/pem/file/test.com.key",  // full path to pem file private key
-                    "public_key_file":"/path/to/pem/file/test.com.crt", // full path to pem file certificate
-                    "timeout":180, // timeout in number of seconds before an idle connection is closed
-                    "listen_interface":"127.0.0.1:25", // listen on ip and port
-                    "start_tls_on":true, // supports the STARTTLS command?
-                    "tls_always_on":false, // always connect using TLS? If true, start_tls_on will be false
-                    "max_clients": 1000, // max clients at one time
-                    "log_file":"/dev/stdout" // where to log to
-                },
-                // the following is a second server, but listening on port 465 and always using TLS
-                {
-                    "is_enabled" : true,
-                    "host_name":"mail.test.com",
-                    "max_size":1000000,
-                    "private_key_file":"/path/to/pem/file/test.com.key",
-                    "public_key_file":"/path/to/pem/file/test.com.crt",
-                    "timeout":180,
-                    "listen_interface":"127.0.0.1:465",
-                    "start_tls_on":false,
-                    "tls_always_on":true,
-                    "max_clients":500,
-                    "log_file":"/dev/stdout"
-                }
-                // repeat as many servers as you need
-            ]
+        "backend_name": "guerrilla-db-redis", // what backend to use for saving email. See /backends dir
+        "backend_config" :
+            {
+                "mysql_db":"gmail_mail",
+                "mysql_host":"127.0.0.1:3306",
+                "mysql_pass":"ok",
+                "mysql_user":"root",
+                "mail_table":"new_mail",
+                "redis_interface" : "127.0.0.1:6379",
+                "redis_expire_seconds" : 7200,
+                "save_workers_size" : 3,
+                "primary_mail_host":"sharklasers.com"
+            },
+        "servers" : [ // the following is an array of objects, each object represents a new server that will be spawned
+            {
+                "is_enabled" : true, // boolean
+                "host_name":"mail.test.com", // the hostname of the server as set by MX record
+                "max_size": 1000000, // maximum size of an email in bytes
+                "private_key_file":"/path/to/pem/file/test.com.key",  // full path to pem file private key
+                "public_key_file":"/path/to/pem/file/test.com.crt", // full path to pem file certificate
+                "timeout":180, // timeout in number of seconds before an idle connection is closed
+                "listen_interface":"127.0.0.1:25", // listen on ip and port
+                "start_tls_on":true, // supports the STARTTLS command?
+                "tls_always_on":false, // always connect using TLS? If true, start_tls_on will be false
+                "max_clients": 1000, // max clients at one time
+                "log_file":"/dev/stdout" // where to log to
+            },
+            // the following is a second server, but listening on port 465 and always using TLS
+            {
+                "is_enabled" : true,
+                "host_name":"mail.test.com",
+                "max_size":1000000,
+                "private_key_file":"/path/to/pem/file/test.com.key",
+                "public_key_file":"/path/to/pem/file/test.com.crt",
+                "timeout":180,
+                "listen_interface":"127.0.0.1:465",
+                "start_tls_on":false,
+                "tls_always_on":true,
+                "max_clients":500,
+                "log_file":"/dev/stdout"
+            }
+            // repeat as many servers as you need
+        ]
     }
 
 The Json parser is very strict on syntax. If there's a parse error and it
 doesn't give much clue, then test your syntax here:
 http://jsonlint.com/#
 	
+Email Saving Backends
+=====================
+
+Backends provide for a modular way to save email and for the ability to
+extend this functionality. They can be swapped in or out via the config. 
+Currently, the server comes with two example backends: 
+
+- dummy : used for testing purposes
+- guerrilla_db_redis: example uses MySQL and Redis to store email, used on Guerrilla Mail
+
+
 
 Releases
 =========================================================
+1.6
+- New modular backends
+- Hot-reloading of configuration
+- Basic pooling: Internally, clients are now managed with a pool
+
 1.5.1 - 4nd Nov 2016
 - Small optimizations to the way email is saved
 
@@ -294,15 +279,21 @@ Why proxy SMTP with Nginx?
 Starting / Command Line usage
 ==========================================================
 
-All command line arguments are optional
+    Usage:
+      guerrillad [command]
+    
+    Available Commands:
+      serve       start the small SMTP server
+      version     Print the version info
+    
+    Flags:
+      -v, --verbose   print out more debug information
+    
+    Use "guerrillad [command] --help
 
-	-config="goguerrilla.conf": Path to the configuration file
-	 -if="": Interface and port to listen on, eg. 127.0.0.1:2525
-	 -v="n": Verbose, [y | n]
+Starting from the server from line (example)
 
-Starting from the command line (example)
-
-	/usr/bin/nohup /home/mike/goguerrilla -config=/home/mike/goguerrilla.conf 2>&1 &
+	/home/mike/guerrillad serve -config=/home/mike/goguerrilla.conf 2>&1 &
 
 This will place goguerrilla in the background and continue running
 
@@ -330,7 +321,18 @@ with the kill command:
 The above example assumes that you have configured the server to store 
 its own pid in /var/run/go-guerrilla.pid
 
-The new configuration will go in effect for all new connections.
+The new configuration will go in effect for all new connections with the 
+exception of `timeout` and `allowed_hosts` setting changes will take 
+effect immediately.
+
+Any new/enabled servers will be started and old/disabled servers will 
+be gracefully shut down.
+
+If changes to the backend config are detected, the backend will be shut-down 
+and re-spawned.
+
+If changes to the TLS config are detected (eg. key files have changed
+timestamps), they will be reloaded and used for all new connections)
 
 Benchmarking:
 ==========================================================

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Getting started
 
 To build, just run
 
-$ go build
+$ make guerrillad
 
-Rename goguerrilla.conf.sample to goguerrilla.conf
+Then rename goguerrilla.conf.sample to goguerrilla.conf
 
 By default, the saveMail() function saves the meta-data of an email
 into MySQL while the body is saved in Redis.
@@ -316,9 +316,23 @@ Use openssl:
     $ openssl s_client -starttls smtp -crlf -connect 127.0.0.1:2526
 
 
+Reload Config without restarting
+================================
+
+To reload the server config without restarting, send a SIG_HUP signal
+with the kill command:
+
+    sudo kill -HUP `cat /var/run/go-guerrilla.pid`
+
+The above example assumes that you have configured the server to store 
+its own pid in /var/run/go-guerrilla.pid
+
+The new configuration will go in effect for all new connections.
+
 Benchmarking:
 ==========================================================
 
 http://www.jrh.org/smtp/index.html
 Test 500 clients:
-$ time smtp-source -c -l 5000 -t test@spam4.me -s 500 -m 5000 5.9.7.183
+
+    $ time smtp-source -c -l 5000 -t test@spam4.me -s 500 -m 5000 5.9.7.183

--- a/backends/guerrilla_db_redis.go
+++ b/backends/guerrilla_db_redis.go
@@ -51,11 +51,13 @@ func (g *GuerrillaDBAndRedisBackend) loadConfig(backendConfig guerrilla.BackendC
 	g.config = guerrillaDBAndRedisConfig{}
 	s := reflect.ValueOf(&g.config).Elem(); // so that we can set the values
 	typeOfT := s.Type()
-	tags := reflect.TypeOf(g.config) // read the tags of the config struct
+	types := reflect.TypeOf(g.config)
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)
-		field_name := tags.Field(i).Tag.Get("json")
+		// read the tags of the config struct
+		field_name := types.Field(i).Tag.Get("json")
 		if len(field_name) > 0 {
+			// parse the tag to
 			// get the field name from struct tag
 			split := strings.Split(field_name, ",")
 			field_name = split[0]
@@ -64,7 +66,6 @@ func (g *GuerrillaDBAndRedisBackend) loadConfig(backendConfig guerrilla.BackendC
 			// so use the reflected field name
 			field_name = typeOfT.Field(i).Name
 		}
-
 		if f.Type().Name() == "int" {
 			if intVal, converted := backendConfig[field_name].(float64); converted {
 				s.Field(i).SetInt(int64(intVal))
@@ -80,7 +81,6 @@ func (g *GuerrillaDBAndRedisBackend) loadConfig(backendConfig guerrilla.BackendC
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/backends/guerrilla_db_redis.go
+++ b/backends/guerrilla_db_redis.go
@@ -49,7 +49,7 @@ func convertError(name string) error {
 func (g *GuerrillaDBAndRedisBackend) loadConfig(backendConfig guerrilla.BackendConfig) error {
 	// Use reflection so that we can provide a nice error message
 	g.config = guerrillaDBAndRedisConfig{}
-	s := reflect.ValueOf(&g.config).Elem(); // so that we can set the values
+	s := reflect.ValueOf(&g.config).Elem() // so that we can set the values
 	typeOfT := s.Type()
 	types := reflect.TypeOf(g.config)
 	for i := 0; i < s.NumField(); i++ {
@@ -70,14 +70,14 @@ func (g *GuerrillaDBAndRedisBackend) loadConfig(backendConfig guerrilla.BackendC
 			if intVal, converted := backendConfig[field_name].(float64); converted {
 				s.Field(i).SetInt(int64(intVal))
 			} else {
-				return convertError("property missing/invalid: '"+field_name +"' of expected type: "+f.Type().Name())
+				return convertError("property missing/invalid: '" + field_name + "' of expected type: " + f.Type().Name())
 			}
 		}
 		if f.Type().Name() == "string" {
 			if stringVal, converted := backendConfig[field_name].(string); converted {
 				s.Field(i).SetString(stringVal)
 			} else {
-				return convertError("missing/invalid: '"+field_name +"' of type: "+f.Type().Name())
+				return convertError("missing/invalid: '" + field_name + "' of type: " + f.Type().Name())
 			}
 		}
 	}

--- a/cmd/guerrillad/serve.go
+++ b/cmd/guerrillad/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flashmob/go-guerrilla/config"
 	"github.com/flashmob/go-guerrilla/server"
 	"strings"
+	"reflect"
 )
 
 var (
@@ -55,13 +56,17 @@ func sigHandler() {
 
 	for sig := range signalChannel {
 		if sig == syscall.SIGHUP {
+			// save old config & load in new one
 			oldConfig := mainConfig;
-			err := config.ReadConfig(configFile, iface, pidFile, &mainConfig)
+			newConfig := guerrilla.Config{}
+			err := config.ReadConfig(configFile, iface, pidFile, &newConfig)
 			if err != nil {
 				log.WithError(err).Error("Error while ReadConfig (reload)")
 			} else {
+				// mainConfig becomes the new one
+				mainConfig = newConfig
 				emitConfigChangeEvents(oldConfig, mainConfig)
-				log.Infof("Configuration is reloaded at %s", guerrilla.ConfigLoadTime)
+				log.Infof("Configuration was reloaded at %s", guerrilla.ConfigLoadTime)
 			}
 		} else {
 			os.Exit(0)
@@ -70,24 +75,85 @@ func sigHandler() {
 }
 
 func emitConfigChangeEvents(oldConfig guerrilla.Config, newConfig guerrilla.Config) {
+
+	bus.Publish("config_change", newConfig)
 	// has 'allowed hosts' changed?
 	if strings.Compare(oldConfig.AllowedHosts, newConfig.AllowedHosts) != 0 {
 		bus.Publish("config_change:allowed_hosts", newConfig)
 	}
+	// has pid file changed?
 	if strings.Compare(oldConfig.PidFile, newConfig.PidFile) != 0 {
 		bus.Publish("config_change:pid_file", newConfig)
 	}
 
 	// has backend changed?
-	// TODO
+	if !reflect.DeepEqual(oldConfig.BackendConfig, newConfig.BackendConfig)  {
+		bus.Publish("config_change:backend_config", newConfig)
+	}
 
-	// has ssl config changed for any of the servers?
-	// TODO
+	// server config changes
+	oldServers := oldConfig.GetServers()
 
-	// have log files changed?
-	// TODO
+	for iface, newServer := range newConfig.GetServers() {
+		// is server is in both configs?
+		if oldServer, ok := oldServers[iface]; ok {
+			changes := guerrilla.GetChanges(
+				*oldServer,
+				*newServer)
+			// since old server exists in the new config, we do not track it anymore
+			delete(oldServers, iface)
+			// enable or disable?
+			if _, ok := changes["IsEnabled"]; ok {
+				if (newServer.IsEnabled) {
+					bus.Publish("config_change:start_server", newServer)
+				} else {
+					bus.Publish("config_change:"+iface+":stop_server")
+				}
+				// do not emit any more events when IsEnabled changed
+				continue
+			}
+			// log file change?
+			if _, ok := changes["LogFile"]; ok {
+				bus.Publish("config_change:"+iface+":new_log_file", newServer)
+			} else {
+				// since config file has not changed, we reload it
+				bus.Publish("config_change:"+iface+":reopen_log_file", newServer)
+			}
+			// timeout changed
+			if _, ok := changes["Timeout"]; ok {
+				bus.Publish("config_change:"+iface+":timeout", newServer)
+			}
+			// tls changed
+			if  ok := func() bool {
+				if _, ok := changes["PrivateKeyFile"]; ok {
+					return true
+				}
+				if _, ok := changes["PublicKeyFile"]; ok {
+					return true
+				}
+				if _, ok := changes["StartTLS"]; ok {
+					return true
+				}
+				if _, ok := changes["TLSAlwaysOn"]; ok {
+					return true
+				}
 
+				return false
+			}(); ok  {
+				bus.Publish("config_change:"+iface+":tls_config", *newServer)
+			}
 
+		} else {
+			// start new server
+			bus.Publish("config_change:start_server", newServer)
+		}
+
+	}
+	// stop any servers that don't exist anymore
+	for iface := range oldServers {
+		log.Infof("Server [%s] removed from config, stopping", iface)
+		bus.Publish("config_change:"+iface+":stop_server")
+	}
 
 }
 
@@ -110,37 +176,47 @@ func writePid(pidFile string) {
 
 func serve(cmd *cobra.Command, args []string) {
 	logVersion()
-
 	err := config.ReadConfig(configFile, iface, pidFile, &mainConfig)
 	if err != nil {
 		log.WithError(err).Fatal("Error while ReadConfig")
 	}
-
 	// write out our PID
 	writePid(mainConfig.PidFile)
-	// ...and write out our pid whenever the file name changes
+	// ...and write out our pid whenever the file name changes in the config
 	bus.Subscribe("config_change:pid_file", func(mainConfig guerrilla.Config) {
 		writePid(mainConfig.PidFile)
 	})
-
+	// launch backed for saving email
 	backend, err := backends.New(mainConfig.BackendName, mainConfig.BackendConfig)
 	if err != nil {
 		log.WithError(err).Fatalf("Error while loading the backend %q",
 			mainConfig.BackendName)
 	}
-
+	bus.Subscribe("config_change:backend_config", func(mainConfig guerrilla.Config) {
+		backend.Finalize()
+		backend, err = backends.New(mainConfig.BackendName, mainConfig.BackendConfig)
+		if err != nil {
+			log.WithError(err).Fatalf("Error while loading the backend %q",
+				mainConfig.BackendName)
+		}
+	})
 	// run our servers
-	for _, serverConfig := range mainConfig.Servers {
-		if serverConfig.IsEnabled {
-			log.Infof("Starting server on %s", serverConfig.ListenInterface)
-			go func(sConfig guerrilla.ServerConfig) {
-				err := server.RunServer(mainConfig, sConfig, backend, bus)
-				if err != nil {
-					log.WithError(err).Fatalf("Error while starting server on %s", serverConfig.ListenInterface)
-				}
-			}(serverConfig)
+	start := func(sConfig guerrilla.ServerConfig) {
+		log.Infof("Starting server on %s", sConfig.ListenInterface)
+		err := server.RunServer(mainConfig, sConfig, backend, bus)
+		if err != nil {
+			log.WithError(err).Fatalf("Error while starting server on %s", sConfig.ListenInterface)
 		}
 	}
-
+	for _, serverConfig := range mainConfig.Servers {
+		if serverConfig.IsEnabled {
+			go start(serverConfig)
+		}
+	}
+	// start a new server when added to config
+	bus.Subscribe("config_change:start_server", func (sConfig *guerrilla.ServerConfig) {
+		go start(*sConfig)
+	})
+	// trap & handle signals
 	sigHandler()
 }

--- a/cmd/guerrillad/serve.go
+++ b/cmd/guerrillad/serve.go
@@ -16,8 +16,8 @@ import (
 	"github.com/flashmob/go-guerrilla/backends"
 	"github.com/flashmob/go-guerrilla/config"
 	"github.com/flashmob/go-guerrilla/server"
-	"strings"
 	"reflect"
+	"strings"
 )
 
 var (
@@ -57,7 +57,7 @@ func sigHandler() {
 	for sig := range signalChannel {
 		if sig == syscall.SIGHUP {
 			// save old config & load in new one
-			oldConfig := mainConfig;
+			oldConfig := mainConfig
 			newConfig := guerrilla.Config{}
 			err := config.ReadConfig(configFile, iface, pidFile, &newConfig)
 			if err != nil {
@@ -87,7 +87,7 @@ func emitConfigChangeEvents(oldConfig guerrilla.Config, newConfig guerrilla.Conf
 	}
 
 	// has backend changed?
-	if !reflect.DeepEqual(oldConfig.BackendConfig, newConfig.BackendConfig)  {
+	if !reflect.DeepEqual(oldConfig.BackendConfig, newConfig.BackendConfig) {
 		bus.Publish("config_change:backend_config", newConfig)
 	}
 
@@ -104,10 +104,10 @@ func emitConfigChangeEvents(oldConfig guerrilla.Config, newConfig guerrilla.Conf
 			delete(oldServers, iface)
 			// enable or disable?
 			if _, ok := changes["IsEnabled"]; ok {
-				if (newServer.IsEnabled) {
+				if newServer.IsEnabled {
 					bus.Publish("config_change:start_server", newServer)
 				} else {
-					bus.Publish("config_change:"+iface+":stop_server")
+					bus.Publish("config_change:" + iface + ":stop_server")
 				}
 				// do not emit any more events when IsEnabled changed
 				continue
@@ -124,7 +124,7 @@ func emitConfigChangeEvents(oldConfig guerrilla.Config, newConfig guerrilla.Conf
 				bus.Publish("config_change:"+iface+":timeout", newServer)
 			}
 			// tls changed
-			if  ok := func() bool {
+			if ok := func() bool {
 				if _, ok := changes["PrivateKeyFile"]; ok {
 					return true
 				}
@@ -139,7 +139,7 @@ func emitConfigChangeEvents(oldConfig guerrilla.Config, newConfig guerrilla.Conf
 				}
 
 				return false
-			}(); ok  {
+			}(); ok {
 				bus.Publish("config_change:"+iface+":tls_config", *newServer)
 			}
 
@@ -152,7 +152,7 @@ func emitConfigChangeEvents(oldConfig guerrilla.Config, newConfig guerrilla.Conf
 	// stop any servers that don't exist anymore
 	for iface := range oldServers {
 		log.Infof("Server [%s] removed from config, stopping", iface)
-		bus.Publish("config_change:"+iface+":stop_server")
+		bus.Publish("config_change:" + iface + ":stop_server")
 	}
 
 }
@@ -214,7 +214,7 @@ func serve(cmd *cobra.Command, args []string) {
 		}
 	}
 	// start a new server when added to config
-	bus.Subscribe("config_change:start_server", func (sConfig *guerrilla.ServerConfig) {
+	bus.Subscribe("config_change:start_server", func(sConfig *guerrilla.ServerConfig) {
 		go start(*sConfig)
 	})
 	// trap & handle signals

--- a/config.go
+++ b/config.go
@@ -1,21 +1,26 @@
 package guerrilla
 
-import "strings"
+import (
+	"strings"
+)
 
 type BackendConfig map[string]interface{}
 
 // Config is the holder of the configuration of the app
 type Config struct {
-	BackendName   string         `json:"backend_name"`
-	BackendConfig BackendConfig  `json:"backend_config,omitempty"`
-	Servers       []ServerConfig `json:"servers"`
-	AllowedHosts  string         `json:"allowed_hosts"`
+	BackendName        string         `json:"backend_name"`
+	BackendConfig      BackendConfig  `json:"backend_config,omitempty"`
+	Servers            []ServerConfig `json:"servers"`
+	AllowedHosts       string         `json:"allowed_hosts"`
+	PidFile		   string         `json:"pid_file,omitempty"`
 
 	_allowedHosts map[string]bool
 }
 
-func (c *Config) IsAllowed(host string) bool {
+// do we accept this 'rcpt to' host?
+func (c *Config) IsHostAllowed(host string) bool {
 	if c._allowedHosts == nil {
+		// unpack from the config
 		arr := strings.Split(c.AllowedHosts, ",")
 		c._allowedHosts = make(map[string]bool, len(arr))
 		for _, h := range arr {
@@ -23,6 +28,10 @@ func (c *Config) IsAllowed(host string) bool {
 		}
 	}
 	return c._allowedHosts[strings.ToLower(host)]
+}
+
+func (c *Config) ResetAllowedHosts() {
+	c._allowedHosts = nil
 }
 
 // ServerConfig is the holder of the configuration of a server

--- a/config.go
+++ b/config.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"strings"
 
-	"io/ioutil"
-	"fmt"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
 )
 
@@ -24,6 +24,7 @@ type Config struct {
 	_allowedHosts map[string]bool
 	_servers      map[string]*ServerConfig
 }
+
 // load in the config.
 func (c *Config) Load(filename string) error {
 	b, err := ioutil.ReadFile(filename)
@@ -38,7 +39,7 @@ func (c *Config) Load(filename string) error {
 		return errors.New("empty AllowedHosts is not allowed")
 	}
 	// read the timestamps for the ssl keys, to determine if they need to be reloaded
-	for i:=0; i < len(c.Servers); i++ {
+	for i := 0; i < len(c.Servers); i++ {
 		if info, err := os.Stat(c.Servers[i].PrivateKeyFile); err == nil {
 			c.Servers[i]._privateKeyFile_mtime = info.ModTime().Second()
 		}
@@ -105,18 +106,18 @@ func (sc *ServerConfig) GetTlsKeyTimestamps() (int, int) {
 // assuming obj1 and obj2 are of the same struct type
 func GetChanges(obj1 interface{}, obj2 interface{}) map[string]interface{} {
 	ret := make(map[string]interface{}, 5)
-	compareWith := structtomap(obj2);
-	for key, val :=range structtomap(obj1) {
+	compareWith := structtomap(obj2)
+	for key, val := range structtomap(obj1) {
 		if val != compareWith[key] {
 			ret[key] = compareWith[key]
 		}
 	}
 	// detect tls changes (have the key files been modified?)
 	if oldServer, ok := obj1.(ServerConfig); ok {
-		t1, t2 := oldServer.GetTlsKeyTimestamps();
+		t1, t2 := oldServer.GetTlsKeyTimestamps()
 		if newServer, ok := obj2.(ServerConfig); ok {
-			t3, t4 := newServer.GetTlsKeyTimestamps();
-			if   t1 != t3 {
+			t3, t4 := newServer.GetTlsKeyTimestamps()
+			if t1 != t3 {
 				ret["PrivateKeyFile"] = newServer.PrivateKeyFile
 			}
 			if t2 != t4 {
@@ -126,7 +127,6 @@ func GetChanges(obj1 interface{}, obj2 interface{}) map[string]interface{} {
 	}
 	return ret
 }
-
 
 // only able to convert int, bool and string; not recursive
 func structtomap(obj interface{}) map[string]interface{} {

--- a/config.go
+++ b/config.go
@@ -1,20 +1,52 @@
 package guerrilla
 
 import (
+	"reflect"
 	"strings"
+
+	"io/ioutil"
+	"fmt"
+	"encoding/json"
+	"errors"
+	"os"
 )
 
 type BackendConfig map[string]interface{}
 
 // Config is the holder of the configuration of the app
 type Config struct {
-	BackendName        string         `json:"backend_name"`
-	BackendConfig      BackendConfig  `json:"backend_config,omitempty"`
-	Servers            []ServerConfig `json:"servers"`
-	AllowedHosts       string         `json:"allowed_hosts"`
-	PidFile		   string         `json:"pid_file,omitempty"`
+	BackendName   string         `json:"backend_name"`
+	BackendConfig BackendConfig  `json:"backend_config,omitempty"`
+	Servers       []ServerConfig `json:"servers"`
+	AllowedHosts  string         `json:"allowed_hosts"`
+	PidFile       string         `json:"pid_file,omitempty"`
 
 	_allowedHosts map[string]bool
+	_servers      map[string]*ServerConfig
+}
+// load in the config.
+func (c *Config) Load(filename string) error {
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("could not read config file: %s", err)
+	}
+	err = json.Unmarshal(b, c)
+	if err != nil {
+		return fmt.Errorf("could not parse config file: %s", err)
+	}
+	if len(c.AllowedHosts) == 0 {
+		return errors.New("empty AllowedHosts is not allowed")
+	}
+	// read the timestamps for the ssl keys, to determine if they need to be reloaded
+	for i:=0; i < len(c.Servers); i++ {
+		if info, err := os.Stat(c.Servers[i].PrivateKeyFile); err == nil {
+			c.Servers[i]._privateKeyFile_mtime = info.ModTime().Second()
+		}
+		if info, err := os.Stat(c.Servers[i].PublicKeyFile); err == nil {
+			c.Servers[i]._publicKeyFile_mtime = info.ModTime().Second()
+		}
+	}
+	return nil
 }
 
 // do we accept this 'rcpt to' host?
@@ -34,6 +66,18 @@ func (c *Config) ResetAllowedHosts() {
 	c._allowedHosts = nil
 }
 
+// gets the servers in a map for easy lookup
+// key by interface
+func (c *Config) GetServers() map[string]*ServerConfig {
+	if c._servers == nil {
+		c._servers = make(map[string]*ServerConfig, len(c.Servers))
+		for i := 0; i < len(c.Servers); i++ {
+			c._servers[c.Servers[i].ListenInterface] = &c.Servers[i]
+		}
+	}
+	return c._servers
+}
+
 // ServerConfig is the holder of the configuration of a server
 type ServerConfig struct {
 	IsEnabled       bool   `json:"is_enabled"`
@@ -46,4 +90,65 @@ type ServerConfig struct {
 	StartTLS        bool   `json:"start_tls_on,omitempty"`
 	TLSAlwaysOn     bool   `json:"tls_always_on,omitempty"`
 	MaxClients      int    `json:"max_clients"`
+	LogFile         string `json:"log_file,omitempty"`
+
+	_privateKeyFile_mtime int
+	_publicKeyFile_mtime  int
+}
+
+func (sc *ServerConfig) GetTlsKeyTimestamps() (int, int) {
+	return sc._privateKeyFile_mtime, sc._publicKeyFile_mtime
+}
+
+// Return a map with with items whose values changed
+// obj1 and obj2 are struct values, must not be pointer
+// assuming obj1 and obj2 are of the same struct type
+func GetChanges(obj1 interface{}, obj2 interface{}) map[string]interface{} {
+	ret := make(map[string]interface{}, 5)
+	compareWith := structtomap(obj2);
+	for key, val :=range structtomap(obj1) {
+		if val != compareWith[key] {
+			ret[key] = compareWith[key]
+		}
+	}
+	// detect tls changes (have the key files been modified?)
+	if oldServer, ok := obj1.(ServerConfig); ok {
+		t1, t2 := oldServer.GetTlsKeyTimestamps();
+		if newServer, ok := obj2.(ServerConfig); ok {
+			t3, t4 := newServer.GetTlsKeyTimestamps();
+			if   t1 != t3 {
+				ret["PrivateKeyFile"] = newServer.PrivateKeyFile
+			}
+			if t2 != t4 {
+				ret["PublicKeyFile"] = newServer.PublicKeyFile
+			}
+		}
+	}
+	return ret
+}
+
+
+// only able to convert int, bool and string; not recursive
+func structtomap(obj interface{}) map[string]interface{} {
+	ret := make(map[string]interface{}, 0)
+	v := reflect.ValueOf(obj)
+	t := v.Type()
+	for index := 0; index < v.NumField(); index++ {
+		vField := v.Field(index)
+		fName := t.Field(index).Name
+
+		switch vField.Kind() {
+		case reflect.Int:
+			value := vField.Int()
+			ret[fName] = value
+		case reflect.String:
+			value := vField.String()
+			ret[fName] = value
+		case reflect.Bool:
+			value := vField.Bool()
+			ret[fName] = value
+		}
+	}
+	return ret
+
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ReadConfig which should be called at startup, or when a SIG_HUP is caught
-func ReadConfig(configFile, iface string, verbose bool, mainConfig *guerrilla.Config) error {
+func ReadConfig(configFile, iface string, pidFile string, mainConfig *guerrilla.Config) error {
 	// load in the config.
 	b, err := ioutil.ReadFile(configFile)
 	if err != nil {
@@ -27,9 +27,14 @@ func ReadConfig(configFile, iface string, verbose bool, mainConfig *guerrilla.Co
 		return errors.New("empty AllowedHosts is not allowed")
 	}
 
-	// TODO: deprecate
+	// Use the iface passed form command-line rather rather than config file
 	if len(iface) > 0 && len(mainConfig.Servers) > 0 {
 		mainConfig.Servers[0].ListenInterface = iface
+	}
+
+	// same for the file that stores our process id
+	if len(pidFile) > 0 {
+		mainConfig.PidFile = pidFile
 	}
 
 	guerrilla.ConfigLoadTime = time.Now()

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,6 @@
 package config
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
 	"time"
 
 	guerrilla "github.com/flashmob/go-guerrilla"
@@ -12,31 +8,17 @@ import (
 
 // ReadConfig which should be called at startup, or when a SIG_HUP is caught
 func ReadConfig(configFile, iface string, pidFile string, mainConfig *guerrilla.Config) error {
-	// load in the config.
-	b, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		return fmt.Errorf("could not read config file: %s", err)
+	if err := mainConfig.Load(configFile); err != nil {
+		return err
 	}
-
-	err = json.Unmarshal(b, &mainConfig)
-	if err != nil {
-		return fmt.Errorf("could not parse config file: %s", err)
-	}
-
-	if len(mainConfig.AllowedHosts) == 0 {
-		return errors.New("empty AllowedHosts is not allowed")
-	}
-
 	// Use the iface passed form command-line rather rather than config file
 	if len(iface) > 0 && len(mainConfig.Servers) > 0 {
 		mainConfig.Servers[0].ListenInterface = iface
 	}
-
 	// same for the file that stores our process id
 	if len(pidFile) > 0 {
 		mainConfig.PidFile = pidFile
 	}
-
 	guerrilla.ConfigLoadTime = time.Now()
 	return nil
 }

--- a/goguerrilla.conf.sample
+++ b/goguerrilla.conf.sample
@@ -1,10 +1,19 @@
 {
     "allowed_hosts": "guerrillamail.com,guerrillamailblock.com,sharklasers.com,guerrillamail.net,guerrillamail.org",
-    "primary_mail_host":"sharklasers.com",
-    "backend_name": "dummy",
-    "backend_config": {
-        "log_received_mails": true
-    },
+    "pid_file" : "/var/run/go-guerrilla.pid",
+    "backend_name": "guerrilla-db-redis",
+    "backend_config" :
+            {
+                "mysql_db":"gmail_mail",
+                "mysql_host":"127.0.0.1:3306",
+                "mysql_pass":"ok",
+                "mysql_user":"root",
+                "mail_table":"new_mail",
+                "redis_interface" : "127.0.0.1:6379",
+            	"redis_expire_seconds" : 7200,
+                "save_workers_size" : 3,
+                "primary_mail_host":"sharklasers.com"
+            },
     "servers" : [
         {
             "is_enabled" : true,
@@ -16,7 +25,8 @@
             "listen_interface":"127.0.0.1:25",
             "start_tls_on":true,
             "tls_always_on":false,
-            "max_clients": 1000
+            "max_clients": 1000,
+            "log_file":"/dev/stdout"
         },
         {
             "is_enabled" : true,
@@ -28,7 +38,8 @@
             "listen_interface":"127.0.0.1:465",
             "start_tls_on":false,
             "tls_always_on":true,
-            "max_clients":500
+            "max_clients":500,
+            "log_file":"/dev/stdout"
         }
     ]
 }

--- a/models.go
+++ b/models.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"time"
 	"sync"
+	"time"
 )
 
 type EmailParts struct {

--- a/models.go
+++ b/models.go
@@ -48,7 +48,7 @@ type Client struct {
 	Errors      int
 	ClientID    uint64
 	SavedNotify chan int
-	mu       sync.Mutex
+	mu          sync.Mutex
 }
 
 func NewClient(conn net.Conn, clientID uint64) *Client {
@@ -68,13 +68,25 @@ func (c *Client) Reset(conn net.Conn, clientID uint64) {
 	// reset our reader & writer
 	c.Bufout.Reset(conn)
 	c.Bufin.Reset(conn)
-
+	// reset session data
 	c.State = 0
 	c.KillTime = 0
 	c.Time = time.Now().Unix()
 	c.ClientID = clientID
 	c.TLS = false
 	c.Errors = 0
+	c.Response = ""
+	c.Helo = ""
+}
+
+func (c *Client) ClearEmailData() {
+	// todo - maybe these could be implemented as buffers? then reset the buffers here
+	c.Data = ""
+	c.Hash = ""
+	c.Address = ""
+	c.Subject = ""
+	c.RcptTo = ""
+	c.MailFrom = ""
 }
 
 func (c *Client) SetTimeout(t time.Duration) {

--- a/server/goguerrilla.go
+++ b/server/goguerrilla.go
@@ -14,12 +14,10 @@ See README for more details
 package server
 
 import (
-	"bufio"
 	"crypto/rand"
 	"crypto/tls"
 	"fmt"
 	"net"
-	"runtime"
 	"time"
 
 	evbus "github.com/asaskevich/EventBus"
@@ -27,6 +25,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	guerrilla "github.com/flashmob/go-guerrilla"
+	"reflect"
 )
 
 // configure SSL using the values from guerrilla.ServerConfig
@@ -48,74 +47,116 @@ func (s *SmtpdServer) configureSSL() error {
 	return nil
 }
 
-
-func (server *SmtpdServer) configureTimeout(t int) {
-	server.timeout = time.Duration(int64(t))
+// Set the timeout for the server and all clients
+func (server *SmtpdServer) setTimeout(seconds int) {
+	duration := time.Duration(int64(seconds))
+	server.clientPool.SetTimeout(duration)
+	server.timeout.Store(duration)
 }
 
-func RunServer(mainConfig guerrilla.Config, sConfig guerrilla.ServerConfig, backend guerrilla.Backend, bus *evbus.EventBus) (err error) {
 
-	server := newSmtpdServer(mainConfig, sConfig);
+func RunServer(mainConfig guerrilla.Config,
+	sConfig guerrilla.ServerConfig,
+	backend guerrilla.Backend,
+	bus *evbus.EventBus) (err error) {
+
+	server := newSmtpdServer(mainConfig, sConfig, bus)
+
+	handlerAllowedHosts := func(newConfig guerrilla.Config) {
+		newConfig.ResetAllowedHosts()
+		server.mainConfigStore.Store(newConfig)
+		log.Infof("Allowed hosts config reloaded")
+	}
+	bus.Subscribe("config_change:allowed_hosts", handlerAllowedHosts)
+
+	handlerTimeout := func(newServerConfig *guerrilla.ServerConfig) {
+		server.setTimeout(newServerConfig.Timeout)
+		log.Infof("timeout changed")
+	}
+	bus.Subscribe("config_change:"+sConfig.ListenInterface+":timeout", handlerTimeout)
+	// Configure TLS
 	if err := server.configureSSL(); err != nil {
 		return err
 	}
-
-	bus.Subscribe("config_change:"+sConfig.ListenInterface+":tls_config", func(changedValues guerrilla.ServerConfig) error {
-		// TODO store the new changes
-		//
+	// Re-configure TLS
+	handlerTLS := func(newServerConfig guerrilla.ServerConfig) error {
 		// reload changes for subsequent connections
+		server.configStore.Store(newServerConfig)
 		if err := server.configureSSL(); err != nil {
 			return err
 		}
+		log.Infof("SSL reconfigured for [%s]", sConfig.ListenInterface)
 		return nil
-	})
+	}
+	bus.Subscribe("config_change:"+sConfig.ListenInterface+":tls_config", handlerTLS)
 
-
-	bus.Subscribe("config_change:allowed_hosts", func(mainConfig guerrilla.Config) {
-		mainConfig.ResetAllowedHosts()
-		server.mainConfigStore.Store(mainConfig)
-		log.Infof("Allowed hosts config reloaded")
-	})
-
-	bus.Subscribe("config_change:"+sConfig.ListenInterface+":server_config", func(changedValues guerrilla.ServerConfig) {
-		// change timeout
-
-		// max size
-
-		// start tls
-
-		// max clients - resize server.sem
-	})
-
-
+	var (
+		listener     net.Listener
+		listener_err error
+	)
 
 	// Start listening for SMTP connections
-	listener, err := net.Listen("tcp", sConfig.ListenInterface)
-	if err != nil {
-		return fmt.Errorf("cannot listen on port, %v", err)
+	listener, err = net.Listen("tcp", sConfig.ListenInterface)
+	if listener_err != nil {
+		return fmt.Errorf("cannot listen on port, %v (%s)", listener_err, reflect.TypeOf(listener_err))
 	}
-
 	log.Infof("Listening on tcp %s", sConfig.ListenInterface)
 
-	var clientID int64
+	// Stop listening for new connections on a stop_server event
+	handlerStopServer := func() {
+		if listener != nil {
+			log.Infof("Close listening on interface: %s", sConfig.ListenInterface)
+			listener.Close()
+			// subsequent calls to listener.Accept() will produce a
+			// non-temporary error, then this will function will return.
+			// Not that each individual connections will also receive this event and close themselves
+		}
+	}
+	bus.Subscribe("config_change:"+sConfig.ListenInterface+":stop_server", handlerStopServer)
+	defer func() {
+		if err := bus.Unsubscribe("config_change:"+sConfig.ListenInterface+":stop_server", handlerStopServer); err != nil {
+			log.WithError(err).Debug("bus unsub error")
+		}
+		if err := bus.Unsubscribe("config_change:"+sConfig.ListenInterface+":tls_config", handlerTLS);err != nil {
+			log.WithError(err).Debug("bus unsub error")
+		}
+		if err := bus.Unsubscribe("config_change:"+sConfig.ListenInterface+":timeout", handlerTimeout); err != nil {
+			log.WithError(err).Debug("bus unsub error")
+		}
+		if err := bus.Unsubscribe("config_change:allowed_hosts", handlerAllowedHosts); err != nil {
+			log.WithError(err).Debug("bus unsub error")
+		}
+	}()
+
+	var (
+		clientID uint64
+		client *guerrilla.Client
+		poolErr error
+	)
 	clientID = 1
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			log.WithError(err).Infof("Accept error")
+			if e, ok := err.(net.Error); ok && !e.Temporary() {
+				// most likely the socket has been closed (stop_server event caught)
+				// send an event to wait for existing connections to close
+				server.Shutdown()
+				log.Infof("Server [%s] has stopped", sConfig.ListenInterface)
+				return nil
+			}
+			log.WithError(err).Infof("Accept error (%s) ", reflect.TypeOf(err))
 			continue
 		}
-		log.Debugf("Number of serving goroutines: %d", runtime.NumGoroutine())
-		server.sem <- 1 // Wait for active queue to drain.
-		go server.handleClient(&guerrilla.Client{
-			Conn:        conn,
-			Address:     conn.RemoteAddr().String(),
-			Time:        time.Now().Unix(),
-			Bufin:       guerrilla.NewSMTPBufferedReader(conn),
-			Bufout:      bufio.NewWriter(conn),
-			ClientID:    clientID,
-			SavedNotify: make(chan int),
-		}, backend)
+		// grab a client form the pool, will block if full
+		client, poolErr = server.clientPool.Borrow(conn, clientID);
+		if poolErr == ErrPoolShuttingDown {
+			continue
+		}
+		go func () {
+			server.handleClient(client, backend)
+			server.clientPool.Return(client)
+		}()
 		clientID++
 	}
+	return nil
 }

--- a/server/goguerrilla.go
+++ b/server/goguerrilla.go
@@ -54,7 +54,6 @@ func (server *SmtpdServer) setTimeout(seconds int) {
 	server.timeout.Store(duration)
 }
 
-
 func RunServer(mainConfig guerrilla.Config,
 	sConfig guerrilla.ServerConfig,
 	backend guerrilla.Backend,
@@ -117,7 +116,7 @@ func RunServer(mainConfig guerrilla.Config,
 		if err := bus.Unsubscribe("config_change:"+sConfig.ListenInterface+":stop_server", handlerStopServer); err != nil {
 			log.WithError(err).Debug("bus unsub error")
 		}
-		if err := bus.Unsubscribe("config_change:"+sConfig.ListenInterface+":tls_config", handlerTLS);err != nil {
+		if err := bus.Unsubscribe("config_change:"+sConfig.ListenInterface+":tls_config", handlerTLS); err != nil {
 			log.WithError(err).Debug("bus unsub error")
 		}
 		if err := bus.Unsubscribe("config_change:"+sConfig.ListenInterface+":timeout", handlerTimeout); err != nil {
@@ -130,8 +129,8 @@ func RunServer(mainConfig guerrilla.Config,
 
 	var (
 		clientID uint64
-		client *guerrilla.Client
-		poolErr error
+		client   *guerrilla.Client
+		poolErr  error
 	)
 	clientID = 1
 	for {
@@ -148,11 +147,11 @@ func RunServer(mainConfig guerrilla.Config,
 			continue
 		}
 		// grab a client form the pool, will block if full
-		client, poolErr = server.clientPool.Borrow(conn, clientID);
+		client, poolErr = server.clientPool.Borrow(conn, clientID)
 		if poolErr == ErrPoolShuttingDown {
 			continue
 		}
-		go func () {
+		go func() {
 			server.handleClient(client, backend)
 			server.clientPool.Return(client)
 		}()

--- a/server/pool.go
+++ b/server/pool.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"github.com/flashmob/go-guerrilla"
+	"net"
+	"errors"
+	"sync/atomic"
+	"time"
+	"sync")
+
+var (
+	ErrPoolShuttingDown = errors.New("server pool: shutting down")
+)
+
+// Pool holds Clients.
+type Pool struct {
+	pool              chan *guerrilla.Client
+	activeClients     chan *guerrilla.Client
+	clients           allClients
+	isShuttingDownFlg atomic.Value
+	borrowGuard       sync.Mutex
+}
+
+type allClients struct {
+	m    map[uint64]*guerrilla.Client
+	mu   sync.Mutex // guards access to this struct
+}
+
+
+// NewPool creates a new pool of Clients.
+func NewPool(poolSize int) *Pool {
+	return &Pool{
+		pool:   make(chan *guerrilla.Client, poolSize),
+		activeClients: make(chan *guerrilla.Client, poolSize),
+		clients: allClients{m:make(map[uint64]*guerrilla.Client, poolSize)},
+	}
+}
+
+// Lock the pool from borrowing then remove all active clients
+// each active client's timeout is lowered to 1 sec and notified
+// to stop accepting commands
+func (p *Pool) Shutdown() {
+	const aVeryLowTimeout = 1
+	p.borrowGuard.Lock() // lock indefinitely from borrowing from the pool
+	p.isShuttingDownFlg.Store(true)
+	var client *guerrilla.Client
+	// remove active clients
+	for ; ; {
+		if len(p.activeClients) == 0 {
+			// nothing to remove
+			goto Done
+		}
+		client = <- p.activeClients
+		client.SetTimeout(time.Duration(int64(aVeryLowTimeout)))
+		killClient(client)
+	}
+	Done:
+	close(p.activeClients)
+}
+
+// returns true if the pool is shutting down
+func (p *Pool) IsShuttingDown() bool {
+	return p.isShuttingDownFlg.Load().(bool)
+}
+
+// set a timeout for all clients
+func (p *Pool) SetTimeout(duration time.Duration) {
+	var client *guerrilla.Client
+	p.clients.mu.Lock()
+	defer p.clients.mu.Unlock()
+	for _, client = range p.clients.m {
+		client.SetTimeout(duration)
+	}
+}
+
+// Gets the number of active clients that are currently
+// out of the pool and busy serving
+func (p *Pool) GetActiveClientsCount() int {
+	return len(p.activeClients)
+}
+
+// Borrow a Client from the pool. Will block if len(activeClients) > maxClients
+func (p *Pool) Borrow(conn net.Conn, clientID uint64) (*guerrilla.Client, error) {
+	p.borrowGuard.Lock()
+	defer p.borrowGuard.Unlock()
+	var c *guerrilla.Client
+	if yes, really := p.isShuttingDownFlg.Load().(bool); yes && really {
+		// pool is shutting down.
+		return c, ErrPoolShuttingDown
+	}
+	select {
+	case c = <-p.pool:
+		c.Reset(conn, clientID)
+	default:
+		c = guerrilla.NewClient(conn, clientID)
+		p.clients.mu.Lock()
+		p.clients.m[clientID] = c
+		p.clients.mu.Unlock()
+	}
+	p.activeClients <- c // block the client from serving until there is room
+	return c, nil
+}
+
+// Return returns a Client back to the pool.
+func (p *Pool) Return(c *guerrilla.Client) {
+	select {
+	case p.pool <- c:
+	default:
+		// hasta la vista, baby...
+		p.clients.mu.Lock()
+		delete(p.clients.m, c.ClientID)
+		p.clients.mu.Unlock()
+	}
+	<-p.activeClients // make room for the next serving client
+}

--- a/server/pool.go
+++ b/server/pool.go
@@ -105,6 +105,7 @@ func (p *Pool) Borrow(conn net.Conn, clientID uint64) (*guerrilla.Client, error)
 func (p *Pool) Return(c *guerrilla.Client) {
 	select {
 	case p.pool <- c:
+		c.ClearEmailData()
 	default:
 		// hasta la vista, baby...
 		p.clients.mu.Lock()

--- a/server/smtpd.go
+++ b/server/smtpd.go
@@ -122,8 +122,8 @@ func (server *SmtpdServer) handleClient(client *guerrilla.Client, backend guerri
 					"250-SIZE %d\r\n" +
 					"250-PIPELINING\r\n" +
 					"%s250 HELP",
-					server.config.Hostname, client.Helo, client.Address,
-					server.config.MaxSize, advertiseTLS))
+					sConfig.Hostname, client.Helo, client.Address,
+					sConfig.MaxSize, advertiseTLS))
 			case strings.Index(cmd, "HELP") == 0:
 				responseAdd(client, "250 Help! I need somebody...")
 			case strings.Index(cmd, "MAIL FROM:") == 0:

--- a/server/smtpd.go
+++ b/server/smtpd.go
@@ -14,8 +14,8 @@ import (
 
 	guerrilla "github.com/flashmob/go-guerrilla"
 	"github.com/flashmob/go-guerrilla/util"
-	"sync/atomic"
 	"sync"
+	"sync/atomic"
 )
 
 type SmtpdServer struct {
@@ -33,15 +33,14 @@ type SmtpdServer struct {
 
 func newSmtpdServer(mainConfig guerrilla.Config, sConfig guerrilla.ServerConfig, bus *evbus.EventBus) *SmtpdServer {
 	server := SmtpdServer{
-		bus:           bus,
-		clientPool:    NewPool(sConfig.MaxClients),
+		bus:        bus,
+		clientPool: NewPool(sConfig.MaxClients),
 	}
 	server.mainConfigStore.Store(mainConfig)
 	server.configStore.Store(sConfig)
 	server.setTimeout(sConfig.Timeout)
 	return &server
 }
-
 
 // Upgrades the connection to TLS
 // Sets up buffers with the upgraded connection
@@ -73,7 +72,7 @@ func (server *SmtpdServer) Shutdown() {
 
 func (server *SmtpdServer) isShuttingDown() bool {
 	if is, really := server.shuttingDownFlag.Load().(bool); is && really {
-		return true;
+		return true
 	}
 	return false
 }
@@ -109,7 +108,7 @@ func (server *SmtpdServer) handleClient(client *guerrilla.Client, backend guerri
 		// STARTTLS turned off
 		advertiseTLS = ""
 	}
-	for ;; {
+	for {
 		switch client.State {
 		case 0:
 			responseAdd(client, greeting)
@@ -122,7 +121,7 @@ func (server *SmtpdServer) handleClient(client *guerrilla.Client, backend guerri
 					log.WithError(err).Debugf("Client closed the connection already: %s", client.Address)
 					return
 				}
-				if (server.isShuttingDown()) {
+				if server.isShuttingDown() {
 					break // do not accept anymore commands
 				}
 				if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
@@ -156,9 +155,9 @@ func (server *SmtpdServer) handleClient(client *guerrilla.Client, backend guerri
 				}
 				responseAdd(client, fmt.Sprintf(
 					"250-%s Hello %s[%s]\r\n"+
-					"250-SIZE %d\r\n" +
-					"250-PIPELINING\r\n" +
-					"%s250 HELP",
+						"250-SIZE %d\r\n"+
+						"250-PIPELINING\r\n"+
+						"%s250 HELP",
 					sConfig.Hostname, client.Helo, client.Address,
 					sConfig.MaxSize, advertiseTLS))
 			case strings.Index(cmd, "HELP") == 0:
@@ -237,7 +236,7 @@ func (server *SmtpdServer) handleClient(client *guerrilla.Client, backend guerri
 					log.WithError(err).Debugf("Client closed the connection already: %s", client.Address)
 					return
 				}
-				if (server.isShuttingDown()) {
+				if server.isShuttingDown() {
 					// When shutting down in DATA state, the server will let the client
 					// finish the email, unless a timeout is detected.
 					break
@@ -261,7 +260,7 @@ func (server *SmtpdServer) handleClient(client *guerrilla.Client, backend guerri
 
 		case 3:
 			// upgrade to TLS
-			if tlsErr :=server.upgradeToTls(client); tlsErr == nil {
+			if tlsErr := server.upgradeToTls(client); tlsErr == nil {
 				advertiseTLS = ""
 				client.State = 1
 			} else {
@@ -287,7 +286,7 @@ func (server *SmtpdServer) handleClient(client *guerrilla.Client, backend guerri
 			}
 		}
 		if client.KillTime > 1 {
-			if (server.isShuttingDown() && client.State != 4) {
+			if server.isShuttingDown() && client.State != 4 {
 				client.State = 4
 			} else {
 				return


### PR DESCRIPTION
So far, it has

- introduced an 'event bus', used to generate events when config file changes. Concerning code can then pick up the events and handle them accordingly.
- Introduced atomic read/write of configuration values
- reload config on HUP for allowed hosts
- reload config on HUP for pid file

still to do:

- detection of interface changes, emit & handle these events
- server config changes, emit & handle this event
- backend config changes, emit & handle
- log file config & changes, ""