### PR TITLE
skip host check if allowed_hosts has a single entry and the entry is a .

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -443,7 +443,7 @@ func TestReloadConfig(t *testing.T) {
 	os.Truncate("tests/testlog", 0)
 	d := Daemon{}
 	d.Start()
-
+	defer d.Shutdown()
 	cfg := AppConfig{
 		LogFile:      "tests/testlog",
 		AllowedHosts: []string{"grr.la"},
@@ -455,7 +455,6 @@ func TestReloadConfig(t *testing.T) {
 	// Look mom, reloading the config without shutting down!
 	d.ReloadConfig(cfg)
 
-	d.Shutdown()
 }
 
 func TestPubSubAPI(t *testing.T) {
@@ -464,7 +463,7 @@ func TestPubSubAPI(t *testing.T) {
 
 	d := Daemon{Config: &AppConfig{LogFile: "tests/testlog"}}
 	d.Start()
-
+	defer d.Shutdown()
 	// new config
 	cfg := AppConfig{
 		PidFile:      "tests/pidfilex.pid",
@@ -539,6 +538,7 @@ func TestAPILog(t *testing.T) {
 func TestSkipAllowsHost(t *testing.T) {
 
 	d := Daemon{}
+	defer d.Shutdown()
 	// setting the allowed hosts to a single entry with a dot will let any host through
 	d.Config = &AppConfig{AllowedHosts: []string{"."}, LogFile: "off"}
 	d.Start()

--- a/server.go
+++ b/server.go
@@ -231,9 +231,15 @@ func (server *server) GetActiveClientsCount() int {
 }
 
 // Verifies that the host is a valid recipient.
+// host checking turned off if there is a single entry and it's a dot.
 func (server *server) allowsHost(host string) bool {
 	server.hosts.Lock()
 	defer server.hosts.Unlock()
+	if len(server.hosts.table) == 1 {
+		if _, ok := server.hosts.table["."]; ok {
+			return true
+		}
+	}
 	if _, ok := server.hosts.table[strings.ToLower(host)]; ok {
 		return true
 	}
@@ -429,7 +435,6 @@ func (server *server) handleClient(client *client) {
 						} else {
 							client.sendResponse(response.Canned.SuccessRcptCmd)
 						}
-
 					}
 				}
 


### PR DESCRIPTION
This is so validating processors can do the host check.

 Allow disabling the default allowed_hosts check, by configuring it with a single item containing a ".". Another way would be to do an empty list, however, an administrator may accidentally leave the list empty, so It's better to have something explicit.