### PR TITLE
Add wildcard-processor to available processors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ The following processors can be imported to your project, then use the
 | Processor | Description |
 |-----------|-------------|
 |[MailDir](https://github.com/flashmob/maildir-processor)|Save emails to a maildir. [MailDiranasaurus](https://github.com/flashmob/maildiranasaurus) is an example project|
-|[FastCGI](https://github.com/flashmob/fastcgi-processor)|Deliver email directly to PHP-FPM or a similar FastCGI backend.
+|[FastCGI](https://github.com/flashmob/fastcgi-processor)|Deliver email directly to PHP-FPM or a similar FastCGI backend.|
+|[WildcardProcessor](https://github.com/DevelHell/wildcard-processor)|Use wildcards for recipients host validation.|
 
 Have a processor that you would like to share? Submit a PR to add it to the list!
 


### PR DESCRIPTION
According to https://github.com/flashmob/go-guerrilla/pull/73 I created new processor for recipient hosts validation with wildcards. It might be handy to mention this package in go-guerilla documentation.