### PR TITLE
Added an Option to receive  email for subdomains.

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,8 @@ type AppConfig struct {
 	Servers []ServerConfig `json:"servers"`
 	// AllowedHosts lists which hosts to accept email for. Defaults to os.Hostname
 	AllowedHosts []string `json:"allowed_hosts"`
+	// AllowedHostsSubdomains lists which hosts we accept subdomains
+	AllowedHostsSubdomains []string `json:"allowed_hosts_subdomains"`
 	// PidFile is the path for writing out the process id. No output if empty
 	PidFile string `json:"pid_file"`
 	// LogFile is where the logs go. Use path to file, or "stderr", "stdout"

--- a/guerrilla.go
+++ b/guerrilla.go
@@ -199,7 +199,7 @@ func (g *guerrilla) subscribeEvents() {
 	// allowed_hosts changed, set for all servers
 	g.Subscribe(EventConfigAllowedHosts, func(c *AppConfig) {
 		g.mapServers(func(server *server) {
-			server.setAllowedHosts(c.AllowedHosts,c.AllowedHostsSubdomains)
+			server.setAllowedHosts(c.AllowedHosts, c.AllowedHostsSubdomains)
 		})
 		g.mainlog().Infof("allowed_hosts config changed, a new list was set")
 	})

--- a/guerrilla.go
+++ b/guerrilla.go
@@ -131,7 +131,7 @@ func (g *guerrilla) makeServers() error {
 			}
 			if server != nil {
 				g.servers[sc.ListenInterface] = server
-				server.setAllowedHosts(g.Config.AllowedHosts)
+				server.setAllowedHosts(g.Config.AllowedHosts, g.Config.AllowedHostsSubdomains)
 			}
 		}
 	}
@@ -199,7 +199,7 @@ func (g *guerrilla) subscribeEvents() {
 	// allowed_hosts changed, set for all servers
 	g.Subscribe(EventConfigAllowedHosts, func(c *AppConfig) {
 		g.mapServers(func(server *server) {
-			server.setAllowedHosts(c.AllowedHosts)
+			server.setAllowedHosts(c.AllowedHosts,c.AllowedHostsSubdomains)
 		})
 		g.mainlog().Infof("allowed_hosts config changed, a new list was set")
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -52,7 +52,7 @@ func getMockServerConn(sc *ServerConfig, t *testing.T) (*mocks.Conn, *server) {
 	if err != nil {
 		//t.Error("new server failed because:", err)
 	} else {
-		server.setAllowedHosts([]string{"test.com"},[]string{})
+		server.setAllowedHosts([]string{"test.com"}, []string{})
 	}
 	conn := mocks.NewConn()
 	return conn, server

--- a/server_test.go
+++ b/server_test.go
@@ -52,7 +52,7 @@ func getMockServerConn(sc *ServerConfig, t *testing.T) (*mocks.Conn, *server) {
 	if err != nil {
 		//t.Error("new server failed because:", err)
 	} else {
-		server.setAllowedHosts([]string{"test.com"})
+		server.setAllowedHosts([]string{"test.com"},[]string{})
 	}
 	conn := mocks.NewConn()
 	return conn, server


### PR DESCRIPTION
As per my comments in #73 this is a patch to allow sub domains, to be accepted.  Wild cards should be in a processor, but I feel subdomains should be part of the main code.

This also allows having a mixture of the faster hard coded domains.

Im not to happy with the code duplication in the tests, I can reduce it by iterating over a map of 'test' structs.

TODO: add some docs