### PR TITLE
Make cgo iconv package optional #103

### DIFF
--- a/cmd/guerrillad/serve.go
+++ b/cmd/guerrillad/serve.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/flashmob/go-guerrilla"
 	"github.com/flashmob/go-guerrilla/log"
+	//_ "github.com/flashmob/go-guerrilla/mail/iconv"
+	_ "github.com/flashmob/go-guerrilla/mail/encoding"
 	"github.com/spf13/cobra"
 
 	_ "github.com/go-sql-driver/mysql"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ab5586e1ee56f15336e425d99f774acd4f6bc0f042ab597248366592d8c0b1bf
-updated: 2018-03-11T09:23:13.245258041+11:00
+updated: 2018-03-11T11:39:28.566276841+11:00
 imports:
 - name: github.com/asaskevich/EventBus
   version: 68a521d7cbbb7a859c2608b06342f384b3bd5f5a
@@ -16,8 +16,6 @@ imports:
   version: 274df120e9065bdd08eb1120e0375e3dc1ae8465
   subpackages:
   - fs
-- name: github.com/Sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/sirupsen/logrus
   version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/cobra

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 5814d6f4dae438aa3698f98f86dc83fb840e512ab03b8209253c8d6da533399a
-updated: 2017-03-22T19:21:41.269543298+11:00
+hash: ab5586e1ee56f15336e425d99f774acd4f6bc0f042ab597248366592d8c0b1bf
+updated: 2018-03-11T09:23:13.245258041+11:00
 imports:
 - name: github.com/asaskevich/EventBus
-  version: 52a0dcfcbd8299da13aad44b96a6642dd79cbb08
+  version: 68a521d7cbbb7a859c2608b06342f384b3bd5f5a
 - name: github.com/garyburd/redigo
   version: 8873b2f1995f59d4bcdd2b0dc9858e2cb9bf0c13
   subpackages:
@@ -12,16 +12,52 @@ imports:
   version: a0583e0143b1624142adab07e0e97fe106d99561
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/rakyll/statik
+  version: 274df120e9065bdd08eb1120e0375e3dc1ae8465
+  subpackages:
+  - fs
 - name: github.com/Sirupsen/logrus
-  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+- name: github.com/sirupsen/logrus
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/cobra
   version: b62566898a99f2db9c68ed0026aa0a052e59678d
 - name: github.com/spf13/pflag
   version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
+- name: golang.org/x/crypto
+  version: c7dcf104e3a7a1417abc0230cb0d5240d764159d
+  subpackages:
+  - ssh/terminal
+- name: golang.org/x/net
+  version: d0aafc73d5cdc42264b0af071c261abac580695e
+  subpackages:
+  - html
+  - html/atom
+  - html/charset
 - name: golang.org/x/sys
-  version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
+  version: 7dca6fe1f43775aa6d1334576870ff63f978f539
   subpackages:
   - unix
+  - windows
+- name: golang.org/x/text
+  version: b7ef84aaf62aa3e70962625c80a571ae7c17cb40
+  subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - internal/language
+  - internal/tag
+  - internal/utf8internal
+  - language
+  - runes
+  - transform
 - name: gopkg.in/iconv.v1
   version: 16a760eb7e186ae0e3aedda00d4a1daa4d0701d8
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/flashmob/go-guerrilla
 import:
-- package: github.com/Sirupsen/logrus
-  version: ~0.11.0
+- package: github.com/sirupsen/logrus
+  version: ~1.0.4
 - package: github.com/garyburd/redigo
   version: ~1.0.0
   subpackages:
@@ -10,6 +10,11 @@ import:
 - package: gopkg.in/iconv.v1
   version: ~1.1.1
 - package: github.com/asaskevich/EventBus
-  version: 52a0dcfcbd8299da13aad44b96a6642dd79cbb08
+  version: 68a521d7cbbb7a859c2608b06342f384b3bd5f5a
 - package: github.com/go-sql-driver/mysql
   version: ^1.3.0
+- package: golang.org/x/sys
+  version: 7dca6fe1f43775aa6d1334576870ff63f978f539
+- package: golang.org/x/net
+  subpackages:
+  - html/charset

--- a/mail/encoding/encoding.go
+++ b/mail/encoding/encoding.go
@@ -1,0 +1,20 @@
+// encoding enables using golang.org/x/net/html/charset for converting 7bit to UTF-8.
+// golang.org/x/net/html/charset supports a larger range of encodings.
+// when importing, place an underscore _ in front to import for side-effects
+
+package encoding
+
+import (
+	"io"
+
+	"github.com/flashmob/go-guerrilla/mail"
+	cs "golang.org/x/net/html/charset"
+)
+
+func init() {
+
+	mail.Dec.CharsetReader = func(charset string, input io.Reader) (io.Reader, error) {
+		return cs.NewReaderLabel(charset, input)
+	}
+
+}

--- a/mail/encoding/encoding_test.go
+++ b/mail/encoding/encoding_test.go
@@ -1,0 +1,19 @@
+package encoding
+
+import (
+	"github.com/flashmob/go-guerrilla/mail"
+	"strings"
+	"testing"
+)
+
+// This will use the golang.org/x/net/html/charset encoder
+func TestEncodingMimeHeaderDecode(t *testing.T) {
+	str := mail.MimeHeaderDecode("=?ISO-2022-JP?B?GyRCIVo9dztSOWJAOCVBJWMbKEI=?=")
+	if i := strings.Index(str, "【女子高生チャ"); i != 0 {
+		t.Error("expecting 【女子高生チャ, got:", str)
+	}
+	str = mail.MimeHeaderDecode("=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>")
+	if strings.Index(str, "André Pirard") != 0 {
+		t.Error("expecting André Pirard, got:", str)
+	}
+}

--- a/mail/envelope_test.go
+++ b/mail/envelope_test.go
@@ -6,10 +6,20 @@ import (
 	"testing"
 )
 
+// Test MimeHeader decoding, not using iconv
 func TestMimeHeaderDecode(t *testing.T) {
-	str := MimeHeaderDecode("=?ISO-2022-JP?B?GyRCIVo9dztSOWJAOCVBJWMbKEI=?=")
-	if i := strings.Index(str, "【女子高生チャ"); i != 0 {
-		t.Error("expecting 【女子高生チャ, got:", str)
+
+	/*
+		Normally this would fail if not using iconv
+		str := MimeHeaderDecode("=?ISO-2022-JP?B?GyRCIVo9dztSOWJAOCVBJWMbKEI=?=")
+		if i := strings.Index(str, "【女子高生チャ"); i != 0 {
+			t.Error("expecting 【女子高生チャ, got:", str)
+		}
+	*/
+
+	str := MimeHeaderDecode("=?utf-8?B?55So5oi34oCcRXBpZGVtaW9sb2d5IGluIG51cnNpbmcgYW5kIGg=?=  =?utf-8?B?ZWFsdGggY2FyZSBlQm9vayByZWFkL2F1ZGlvIGlkOm8=?=  =?utf-8?B?cTNqZWVr4oCd5Zyo572R56uZ4oCcU1BZ5Lit5paH5a6Y5pa5572R56uZ4oCd?=  =?utf-8?B?55qE5biQ5Y+36K+m5oOF?=")
+	if i := strings.Index(str, "用户“Epidemiology in nursing and h  ealth care eBook read/audio id:o  q3jeek”在网站“SPY中文官方网站”  的帐号详情"); i != 0 {
+		t.Error("expecting 用户“Epidemiology in nursing and h  ealth care eBook read/audio id:o  q3jeek”在网站“SPY中文官方网站”  的帐号详情, got:", str)
 	}
 	str = MimeHeaderDecode("=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>")
 	if strings.Index(str, "André Pirard") != 0 {

--- a/mail/iconv/iconv.go
+++ b/mail/iconv/iconv.go
@@ -1,0 +1,24 @@
+// iconv enables using GNU iconv for converting 7bit to UTF-8.
+// iconv supports a larger range of encodings.
+// It's a cgo package, the build system needs have Gnu library headers available.
+// when importing, place an underscore _ in front to import for side-effects
+package iconv
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/flashmob/go-guerrilla/mail"
+	ico "gopkg.in/iconv.v1"
+)
+
+func init() {
+	mail.Dec.CharsetReader = func(charset string, input io.Reader) (io.Reader, error) {
+		if cd, err := ico.Open("UTF-8", charset); err == nil {
+			r := ico.NewReader(cd, input, 32)
+			return r, nil
+		}
+		return nil, fmt.Errorf("unhandled charset %q", charset)
+	}
+
+}

--- a/mail/iconv/iconv_test.go
+++ b/mail/iconv/iconv_test.go
@@ -1,0 +1,19 @@
+package iconv
+
+import (
+	"github.com/flashmob/go-guerrilla/mail"
+	"strings"
+	"testing"
+)
+
+// This will use the iconv encoder
+func TestIconvMimeHeaderDecode(t *testing.T) {
+	str := mail.MimeHeaderDecode("=?ISO-2022-JP?B?GyRCIVo9dztSOWJAOCVBJWMbKEI=?=")
+	if i := strings.Index(str, "【女子高生チャ"); i != 0 {
+		t.Error("expecting 【女子高生チャ, got:", str)
+	}
+	str = mail.MimeHeaderDecode("=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>")
+	if strings.Index(str, "André Pirard") != 0 {
+		t.Error("expecting André Pirard, got:", str)
+	}
+}


### PR DESCRIPTION
Iconv is now a soft dependency
* Adds a new mail/iconv package and setup an init hook to use iconv whenever it's imported
* Adds a new mail/encoding using same pattern as above (decoder from golang.org/x/text package)
* update envelope.go to use the default charset converter in golang
* update serve.go so that it uses mail/encoding
* update tests