### PR TITLE
Redis: provide a generic interface, import redigo optionally from main

### DIFF
--- a/backends/p_guerrilla_db_redis.go
+++ b/backends/p_guerrilla_db_redis.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/flashmob/go-guerrilla/mail"
-	"github.com/garyburd/redigo/redis"
 )
 
 // ----------------------------------------------------------------------------------
@@ -85,7 +84,7 @@ func (g *GuerrillaDBAndRedisBackend) getNumberOfWorkers() int {
 
 type redisClient struct {
 	isConnected bool
-	conn        redis.Conn
+	conn        RedisConn
 	time        int
 }
 
@@ -328,7 +327,7 @@ func (g *GuerrillaDBAndRedisBackend) sqlConnect() (*sql.DB, error) {
 
 func (c *redisClient) redisConnection(redisInterface string) (err error) {
 	if c.isConnected == false {
-		c.conn, err = redis.Dial("tcp", redisInterface)
+		c.conn, err = RedisDialer("tcp", redisInterface)
 		if err != nil {
 			// handle error
 			return err
@@ -420,6 +419,7 @@ func GuerrillaDbRedis() Decorator {
 					e.MailFrom.String(),
 					e.Subject,
 					ts)
+				e.QueuedId = hash
 				// Add extra headers
 				var addHead string
 				addHead += "Delivered-To: " + to + "\r\n"

--- a/backends/p_redis.go
+++ b/backends/p_redis.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/flashmob/go-guerrilla/mail"
 	"github.com/flashmob/go-guerrilla/response"
-
-	"github.com/garyburd/redigo/redis"
 )
 
 // ----------------------------------------------------------------------------------
@@ -39,12 +37,12 @@ type RedisProcessorConfig struct {
 
 type RedisProcessor struct {
 	isConnected bool
-	conn        redis.Conn
+	conn        RedisConn
 }
 
 func (r *RedisProcessor) redisConnection(redisInterface string) (err error) {
 	if r.isConnected == false {
-		r.conn, err = redis.Dial("tcp", redisInterface)
+		r.conn, err = RedisDialer("tcp", redisInterface)
 		if err != nil {
 			// handle error
 			return err
@@ -113,7 +111,7 @@ func Redis() Decorator {
 					}
 					e.Values["redis"] = "redis" // the next processor will know to look in redis for the message data
 				} else {
-					Log().Error("Redis needs a Hash() process before it")
+					Log().Error("Redis needs a Hasher() process before it")
 					result := NewResult(response.Canned.FailBackendTransaction)
 					return result, StorageError
 				}

--- a/backends/p_redis_test.go
+++ b/backends/p_redis_test.go
@@ -1,0 +1,55 @@
+package backends
+
+import (
+	"github.com/flashmob/go-guerrilla/log"
+	"github.com/flashmob/go-guerrilla/mail"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRedisGeneric(t *testing.T) {
+
+	e := mail.NewEnvelope("127.0.0.1", 1)
+	e.RcptTo = append(e.RcptTo, mail.Address{"test", "grr.la"})
+
+	l, _ := log.GetLogger("./test_redis.log", "debug")
+	g, err := New(BackendConfig{
+		"save_process":         "Hasher|Redis",
+		"redis_interface":      "127.0.0.1:6379",
+		"redis_expire_seconds": 7200,
+	}, l)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = g.Start()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer g.Shutdown()
+	if gateway, ok := g.(*BackendGateway); ok {
+		r := gateway.Process(e)
+		if strings.Index(r.String(), "250 2.0.0 OK") == -1 {
+			t.Error("redis processor didn't result with expected result, it said", r)
+		}
+	}
+	// check the log
+	if _, err := os.Stat("./test_redis.log"); err != nil {
+		t.Error(err)
+		return
+	}
+	if b, err := ioutil.ReadFile("./test_redis.log"); err != nil {
+		t.Error(err)
+		return
+	} else {
+		if strings.Index(string(b), "SETEX") == -1 {
+			t.Error("Log did not contain SETEX, the log was: ", string(b))
+		}
+	}
+
+	os.Remove("./test_redis.log")
+
+}

--- a/backends/p_sql.go
+++ b/backends/p_sql.go
@@ -181,7 +181,6 @@ func SQL() Decorator {
 
 				hash := ""
 				if len(e.Hashes) > 0 {
-					// if saved in redis, hash will be the redis key
 					hash = e.Hashes[0]
 					e.QueuedId = e.Hashes[0]
 				}

--- a/backends/redis_generic.go
+++ b/backends/redis_generic.go
@@ -1,0 +1,45 @@
+package backends
+
+import (
+	"net"
+	"time"
+)
+
+func init() {
+	RedisDialer = func(network, address string, options ...RedisDialOption) (RedisConn, error) {
+		return new(RedisMockConn), nil
+	}
+}
+
+// RedisConn interface provides a generic way to access Redis via drivers
+type RedisConn interface {
+	Close() error
+	Do(commandName string, args ...interface{}) (reply interface{}, err error)
+}
+
+type RedisMockConn struct{}
+
+func (m *RedisMockConn) Close() error {
+	return nil
+}
+
+func (m *RedisMockConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+	Log().Info("redis mock driver command: ", commandName)
+	return nil, nil
+}
+
+type dialOptions struct {
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+	dial         func(network, addr string) (net.Conn, error)
+	db           int
+	password     string
+}
+
+type RedisDialOption struct {
+	f func(*dialOptions)
+}
+
+type redisDial func(network, address string, options ...RedisDialOption) (RedisConn, error)
+
+var RedisDialer redisDial

--- a/backends/storage/redigo/driver.go
+++ b/backends/storage/redigo/driver.go
@@ -1,0 +1,10 @@
+package redigo_driver
+
+import "github.com/flashmob/go-guerrilla/backends"
+import redigo "github.com/gomodule/redigo/redis"
+
+func init() {
+	backends.RedisDialer = func(network, address string, options ...backends.RedisDialOption) (backends.RedisConn, error) {
+		return redigo.Dial(network, address)
+	}
+}

--- a/cmd/guerrillad/serve.go
+++ b/cmd/guerrillad/serve.go
@@ -12,8 +12,14 @@ import (
 
 	"github.com/flashmob/go-guerrilla"
 	"github.com/flashmob/go-guerrilla/log"
+
+	// enable the Redis redigo driver
+	_ "github.com/flashmob/go-guerrilla/backends/storage/redigo"
+
+	// Choose iconv or mail/encoding package which uses golang.org/x/net/html/charset
 	//_ "github.com/flashmob/go-guerrilla/mail/iconv"
 	_ "github.com/flashmob/go-guerrilla/mail/encoding"
+
 	"github.com/spf13/cobra"
 
 	_ "github.com/go-sql-driver/mysql"

--- a/glide.lock
+++ b/glide.lock
@@ -1,33 +1,33 @@
-hash: ab5586e1ee56f15336e425d99f774acd4f6bc0f042ab597248366592d8c0b1bf
-updated: 2018-03-11T11:39:28.566276841+11:00
+hash: f125882976090918727d8badc2f6dbbb8565a91081159ee65d39f667eabc81fe
+updated: 2018-06-11T02:31:42.387414528+10:00
 imports:
 - name: github.com/asaskevich/EventBus
   version: 68a521d7cbbb7a859c2608b06342f384b3bd5f5a
+- name: github.com/go-sql-driver/mysql
+  version: d523deb1b23d913de5bdada721a6071e71283618
 - name: github.com/gomodule/redigo
-  version: 8873b2f1995f59d4bcdd2b0dc9858e2cb9bf0c13
+  version: 9c11da706d9b7902c6da69c592f75637793fe121
   subpackages:
   - internal
   - redis
-- name: github.com/go-sql-driver/mysql
-  version: a0583e0143b1624142adab07e0e97fe106d99561
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/rakyll/statik
-  version: 274df120e9065bdd08eb1120e0375e3dc1ae8465
+  version: fd36b3595eb2ec8da4b8153b107f7ea08504899d
   subpackages:
   - fs
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/spf13/cobra
   version: b62566898a99f2db9c68ed0026aa0a052e59678d
 - name: github.com/spf13/pflag
   version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
 - name: golang.org/x/crypto
-  version: c7dcf104e3a7a1417abc0230cb0d5240d764159d
+  version: 8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: d0aafc73d5cdc42264b0af071c261abac580695e
+  version: 1e491301e022f8f977054da4c2d852decd59571f
   subpackages:
   - html
   - html/atom
@@ -38,7 +38,7 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: b7ef84aaf62aa3e70962625c80a571ae7c17cb40
+  version: 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877
   subpackages:
   - encoding
   - encoding/charmap
@@ -51,11 +51,16 @@ imports:
   - encoding/traditionalchinese
   - encoding/unicode
   - internal/language
+  - internal/language/compact
   - internal/tag
   - internal/utf8internal
   - language
   - runes
   - transform
+- name: google.golang.org/appengine
+  version: b1f26356af11148e710935ed1ac8a7f5702c7612
+  subpackages:
+  - cloudsql
 - name: gopkg.in/iconv.v1
   version: 16a760eb7e186ae0e3aedda00d4a1daa4d0701d8
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: ~1.0.4
 - package: github.com/gomodule/redigo
-  version: ~1.0.0
+  version: ~2.0.0
   subpackages:
   - redis
 - package: github.com/spf13/cobra


### PR DESCRIPTION
issue #94

A new interface has been created for Redis (redis_generic.go) complete with a mock implementation.
A driver is in a different package, in backends/storage/redigo/driver.go
This driver is enabled from serve.go found in the cmd/guerrillad dir, similar to the way the mysql driver is enabled