### PR TITLE
Fix EOF when parsing the envelope headers

### DIFF
--- a/mail/envelope.go
+++ b/mail/envelope.go
@@ -130,7 +130,7 @@ func (e *Envelope) ParseHeaders() error {
 
 	headerEnd := bytes.Index(buf, []byte{'\n', '\n'}) // the first two new-lines chars are the End Of Header
 	if headerEnd > -1 {
-		header := buf[0:headerEnd]
+		header := buf[0:headerEnd+2]
 		headerReader := textproto.NewReader(bufio.NewReader(bytes.NewBuffer(header)))
 		e.Header, err = headerReader.ReadMIMEHeader()
 		if err != nil {

--- a/mail/envelope.go
+++ b/mail/envelope.go
@@ -133,7 +133,7 @@ func (e *Envelope) ParseHeaders() error {
 		header := buf[0:headerEnd+2]
 		headerReader := textproto.NewReader(bufio.NewReader(bytes.NewBuffer(header)))
 		e.Header, err = headerReader.ReadMIMEHeader()
-		if err != nil {
+		if err == nil || err == io.EOF {
 			// decode the subject
 			if subject, ok := e.Header["Subject"]; ok {
 				e.Subject = MimeHeaderDecode(subject[0])

--- a/mail/envelope.go
+++ b/mail/envelope.go
@@ -130,7 +130,7 @@ func (e *Envelope) ParseHeaders() error {
 
 	headerEnd := bytes.Index(buf, []byte{'\n', '\n'}) // the first two new-lines chars are the End Of Header
 	if headerEnd > -1 {
-		header := buf[0:headerEnd+2]
+		header := buf[0 : headerEnd+2]
 		headerReader := textproto.NewReader(bufio.NewReader(bytes.NewBuffer(header)))
 		e.Header, err = headerReader.ReadMIMEHeader()
 		if err == nil || err == io.EOF {


### PR DESCRIPTION
Fixes #139 

The ReadMIMEHeader method should also receive the empty line according to the documentation.