### PR TITLE
Make max header size adjustable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,21 @@
+module github.com/mailchannels/go-guerrilla
+
+replace github.com/flashmob/go-guerilla => /mailchannels/go-guerilla
+
+require (
+	github.com/asaskevich/EventBus v0.0.0-20180103000110-68a521d7cbbb
+	github.com/garyburd/redigo v1.0.0
+	github.com/go-sql-driver/mysql v1.4.1
+	github.com/gomodule/redigo v0.0.0-20160414162804-8873b2f1995f
+	github.com/inconshreveable/mousetrap v1.0.0
+	github.com/rakyll/statik v0.0.0-20181128135655-79258177a57a
+	github.com/sirupsen/logrus v1.0.6
+	github.com/spf13/cobra v0.0.0-20181127133106-d2d81d9a96e2
+	github.com/spf13/pflag v0.0.0-20181223182923-24fa6976df40
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
+	golang.org/x/net v0.0.0-20181220203305-927f97764cc3
+	golang.org/x/sys v0.0.0-20180308152046-7dca6fe1f437
+	golang.org/x/text v0.0.0-20181211190257-17bcc049122f
+	google.golang.org/appengine v1.4.0
+	gopkg.in/iconv.v1 v1.1.1
+)

--- a/mail/envelope.go
+++ b/mail/envelope.go
@@ -117,15 +117,15 @@ func queuedID(clientID uint64) string {
 // Data buffer must be full before calling.
 // It assumes that at most 30kb of email data can be a header
 // Decoding of encoding to UTF is only done on the Subject, where the result is assigned to the Subject field
-func (e *Envelope) ParseHeaders() error {
+func (e *Envelope) ParseHeadersMax(maxHeaderLen int) error {
 	var err error
 	if e.Header != nil {
 		return errors.New("headers already parsed")
 	}
 	buf := e.Data.Bytes()
 	// find where the header ends, assuming that over 30 kb would be max
-	if len(buf) > maxHeaderChunk {
-		buf = buf[:maxHeaderChunk]
+	if maxHeaderLen > 0 && len(buf) > maxHeaderLen {
+		buf = buf[:maxHeaderLen]
 	}
 
 	headerEnd := bytes.Index(buf, []byte{'\n', '\n'}) // the first two new-lines chars are the End Of Header
@@ -143,6 +143,10 @@ func (e *Envelope) ParseHeaders() error {
 		err = errors.New("header not found")
 	}
 	return err
+}
+
+func (e *Envelope) ParseHeaders() error {
+	return e.ParseHeadersMax(maxHeaderChunk)
 }
 
 // Len returns the number of bytes that would be in the reader returned by NewReader()


### PR DESCRIPTION
This creates a new method on Envelope, ParseHeadersMax(int), that takes a single integer paramater which is the maximum length of headers to parse.  

This also configures this as a go module, to make it easier to use with smtp-gateway.