### PR TITLE
Adresses #147 - FreeBSD compatibility

### DIFF
--- a/guerrilla_unix.go
+++ b/guerrilla_unix.go
@@ -11,5 +11,5 @@ func getFileLimit() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return rLimit.Max, nil
+	return uint64(rLimit.Max), nil
 }


### PR DESCRIPTION
since FreeBSD uses int instead of int64, always cast to uint64. 