### PR TITLE
Rename compressor struct to DataCompressor to make it exportable

### DIFF
--- a/backends/p_compressor.go
+++ b/backends/p_compressor.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 // compressedData struct will be compressed using zlib when printed via fmt
-type compressor struct {
+type DataCompressor struct {
 	extraHeaders []byte
 	data         *bytes.Buffer
 	// the pool is used to recycle buffers to ease up on the garbage collector
@@ -39,7 +39,7 @@ type compressor struct {
 }
 
 // newCompressedData returns a new CompressedData
-func newCompressor() *compressor {
+func newCompressor() *DataCompressor {
 	// grab it from the pool
 	var p = sync.Pool{
 		// if not available, then create a new one
@@ -48,13 +48,13 @@ func newCompressor() *compressor {
 			return &b
 		},
 	}
-	return &compressor{
+	return &DataCompressor{
 		pool: &p,
 	}
 }
 
 // Set the extraheaders and buffer of data to compress
-func (c *compressor) set(b []byte, d *bytes.Buffer) {
+func (c *DataCompressor) set(b []byte, d *bytes.Buffer) {
 	c.extraHeaders = b
 	c.data = d
 }
@@ -62,7 +62,7 @@ func (c *compressor) set(b []byte, d *bytes.Buffer) {
 // String implements the Stringer interface.
 // Can only be called once!
 // This is because the compression buffer will be reset and compressor will be returned to the pool
-func (c *compressor) String() string {
+func (c *DataCompressor) String() string {
 	if c.data == nil {
 		return ""
 	}
@@ -84,7 +84,7 @@ func (c *compressor) String() string {
 }
 
 // clear it, without clearing the pool
-func (c *compressor) clear() {
+func (c *DataCompressor) clear() {
 	c.extraHeaders = []byte{}
 	c.data = nil
 }

--- a/backends/p_redis.go
+++ b/backends/p_redis.go
@@ -93,7 +93,7 @@ func Redis() Decorator {
 					var stringer fmt.Stringer
 					// a compressor was set
 					if c, ok := e.Values["zlib-compressor"]; ok {
-						stringer = c.(*compressor)
+						stringer = c.(*DataCompressor)
 					} else {
 						stringer = e
 					}

--- a/backends/p_sql.go
+++ b/backends/p_sql.go
@@ -227,11 +227,11 @@ func SQL() Decorator {
 					e.QueuedId = e.Hashes[0]
 				}
 
-				var co *compressor
+				var co *DataCompressor
 				// a compressor was set by the Compress processor
 				if c, ok := e.Values["zlib-compressor"]; ok {
 					body = "gzip"
-					co = c.(*compressor)
+					co = c.(*DataCompressor)
 				}
 				// was saved in redis by the Redis processor
 				if _, ok := e.Values["redis"]; ok {


### PR DESCRIPTION
This PR is to resolve issue mentioned here: https://github.com/flashmob/go-guerrilla/issues/190.

compressor is unable to be used outside backend package (such as when using go-guerilla as a package and you're trying to customize the built in mysql or redis backends.)