### PR TITLE
Fix conversions to work with Go 1.15

### DIFF
--- a/mail/envelope.go
+++ b/mail/envelope.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/textproto"
 	"strings"
+	"strconv"
 	"sync"
 	"time"
 
@@ -160,7 +161,7 @@ func NewEnvelope(remoteAddr string, clientID uint64) *Envelope {
 }
 
 func queuedID(clientID uint64) string {
-	return fmt.Sprintf("%x", md5.Sum([]byte(string(time.Now().Unix())+string(clientID))))
+	return fmt.Sprintf("%x", md5.Sum([]byte(strconv.FormatInt(time.Now().Unix(), 10)+strconv.FormatUint(clientID, 10))))
 }
 
 // ParseHeaders parses the headers into Header field of the Envelope struct.


### PR DESCRIPTION
As described in https://github.com/golang/go/issues/32479, as of Go 1.15, a warning will be raised when a program attempts to use a string(int) type conversion. For this project, this causes "make test" to fail. This pull request uses strconv methods to convert the values instead, which causes the warning to no longer appear. This pull request fixes #218.