### PR TITLE
Added greeting_type configuration option (#163)

### DIFF
--- a/goguerrilla.conf.sample
+++ b/goguerrilla.conf.sample
@@ -21,6 +21,7 @@
         {
             "is_enabled" : true,
             "host_name":"mail.test.com",
+            "greeting_type": "postfix",
             "max_size": 1000000,
             "timeout":180,
             "listen_interface":"127.0.0.1:25",
@@ -40,6 +41,7 @@
         {
             "is_enabled" : false,
             "host_name":"mail.test.com",
+            "greeting_type": "postfix",
             "max_size":1000000,
             "timeout":180,
             "listen_interface":"127.0.0.1:465",

--- a/server.go
+++ b/server.go
@@ -367,9 +367,13 @@ func (s *server) handleClient(client *client) {
 	s.log().Infof("Handle client [%s], id: %d", client.RemoteIP, client.ID)
 
 	// Initial greeting
-	greeting := fmt.Sprintf("220 %s SMTP Guerrilla(%s) #%d (%d) %s",
-		sc.Hostname, Version, client.ID,
-		s.clientPool.GetActiveClientsCount(), time.Now().Format(time.RFC3339))
+	// GreetingType == "postfix" by default
+	greeting := fmt.Sprintf("220 %s ESMTP Postfix", sc.Hostname)
+	if sc.GreetingType == "guerrilla" {
+		greeting = fmt.Sprintf("220 %s SMTP Guerrilla(%s) #%d (%d) %s",
+			sc.Hostname, Version, client.ID,
+			s.clientPool.GetActiveClientsCount(), time.Now().Format(time.RFC3339))
+	}
 
 	helo := fmt.Sprintf("250 %s Hello", sc.Hostname)
 	// ehlo is a multi-line reply and need additional \r\n at the end

--- a/tests/guerrilla_test.go
+++ b/tests/guerrilla_test.go
@@ -88,6 +88,7 @@ var configJson = `
         {
             "is_enabled" : true,
             "host_name":"mail.guerrillamail.com",
+	    "greeting_type": "postfix",
             "max_size": 100017,
             "timeout":160,
             "listen_interface":"127.0.0.1:2526", 
@@ -104,6 +105,7 @@ var configJson = `
         {
             "is_enabled" : true,
             "host_name":"mail.guerrillamail.com",
+	    "greeting_type": "guerrilla",
             "max_size":1000001,
             "timeout":180,
             "listen_interface":"127.0.0.1:4654",
@@ -242,7 +244,7 @@ func TestGreeting(t *testing.T) {
 	}
 	defer cleanTestArtifacts(t)
 	if startErrors := app.Start(); startErrors == nil {
-		// 1. plaintext connection
+		// 1. plaintext connection, postfix
 		conn, err := net.Dial("tcp", config.Servers[0].ListenInterface)
 		if err != nil {
 			// handle error
@@ -256,14 +258,14 @@ func TestGreeting(t *testing.T) {
 			t.Error(err)
 			t.FailNow()
 		} else {
-			expected := "220 mail.guerrillamail.com SMTP Guerrilla"
+			expected := "220 mail.guerrillamail.com ESMTP Postfix"
 			if strings.Index(greeting, expected) != 0 {
 				t.Error("Server[1] did not have the expected greeting prefix", expected)
 			}
 		}
 		_ = conn.Close()
 
-		// 2. tls connection
+		// 2. tls connection, guerrilla
 		//	roots, err := x509.SystemCertPool()
 		conn, err = tls.Dial("tcp", config.Servers[1].ListenInterface, &tls.Config{
 


### PR DESCRIPTION
This commit adds a greeting_type configuration option, which can be set to "postfix" or "guerrilla". If the Postfix option is selected, the SMTP greeting message will identify the server as Postfix. If the Guerrilla option is selected, the SMTP greeting message will identify the server as Guerrilla.

Having the ability to change how the server identifies itself is a protection against services that check the greeting message in order to detect and block temp mail services. The "postfix" option is set as default, as this will be the most convenient option for most users.

The tests have been updated to handle this change.

This closes #163 (and, potentially, #221).